### PR TITLE
Add CoffeeScript highlighting support

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -18,7 +18,8 @@ h2. What it does
 
 This plugin is pretty basic right now. It currently:
 
-* Sets *Spec.js and *SpecHelper.js files to filetype=jasmine+javascript
+* Sets *Spec.js and *SpecHelper.js files to filetype=jasmine.javascript syntax=jasmine
+* Sets *Spec.coffee and *SpecHelper.coffee files to filetype=jasmine.coffee syntax=jasmine
 * Applies basic syntax highlighting for jasmine keywords in addition to normal javascript syntax
 * Loads snippets for the jasmine filetype for:
 ** desc: description block with before..it..expect

--- a/ftdetect/jasmine.vim
+++ b/ftdetect/jasmine.vim
@@ -1,1 +1,2 @@
 autocmd BufNewFile,BufRead,BufWritePost *Spec.js,*SpecHelper.js set filetype=jasmine.javascript syntax=jasmine
+autocmd BufNewFile,BufRead,BufWritePost *Spec.coffee,*SpecHelper.coffee set filetype=jasmine.coffee syntax=jasmine

--- a/syntax/jasmine.vim
+++ b/syntax/jasmine.vim
@@ -2,7 +2,11 @@ if exists("b:current_syntax")
   finish
 endif
 
-runtime! syntax/javascript.vim
+if &ft =~ "coffee"
+  runtime! syntax/coffee.vim
+else
+  runtime! syntax/javascript.vim
+endif
 
 syn case match
 syn keyword specFunctions afterEach beforeEach describe it expect addMatchers spyOn not

--- a/syntax/jasmine.vim
+++ b/syntax/jasmine.vim
@@ -4,12 +4,14 @@ endif
 
 if &ft =~ "coffee"
   runtime! syntax/coffee.vim
-else
+endif
+
+if !exists("b:current_syntax")
   runtime! syntax/javascript.vim
 endif
 
 syn case match
-syn keyword specFunctions afterEach beforeEach describe it expect addMatchers spyOn not
+syn keyword specFunctions afterEach beforeEach describe it expect addMatchers spyOn not context
 syn keyword specDisabled xit xdescribe
 syn keyword specSpys andCallThrough andReturn andThrow andCallFake callCount argsForCall mostRecentCall
 syn keyword specAsync runs waits waitsFor


### PR DESCRIPTION
I'm writing my Jasmine tests in CoffeeScript now, and your plugin, with a few tiny tweaks for CoffeeScript syntax highlighting selection (from https://github.com/kchmck/vim-coffee-script), make it much nicer. :)
