### PR TITLE
fixes CoffeeScript syntax support

### DIFF
--- a/syntax/jasmine.vim
+++ b/syntax/jasmine.vim
@@ -4,9 +4,7 @@ endif
 
 if &ft =~ "coffee"
   runtime! syntax/coffee.vim
-endif
-
-if !exists("b:current_syntax")
+else
   runtime! syntax/javascript.vim
 endif
 


### PR DESCRIPTION
without this fix all files, regardless of type, include the JavaScript syntax. So CoffeeScript files are not highlighted correctly.

Thanks for the jasmine syntax!
