### PR TITLE
Add support for jasmine-node. Specs should be named as something.spec.cof

### DIFF
--- a/ftdetect/jasmine.vim
+++ b/ftdetect/jasmine.vim
@@ -1,2 +1,2 @@
-autocmd BufNewFile,BufRead,BufWritePost *_[Ss]pec.js,*SpecHelper.js set filetype=jasmine.javascript syntax=jasmine
-autocmd BufNewFile,BufRead,BufWritePost *_[Ss]pec.coffee,*SpecHelper.coffee set filetype=jasmine.coffee syntax=jasmine
+autocmd BufNewFile,BufRead,BufWritePost *[_.][Ss]pec.js,*SpecHelper.js set filetype=jasmine.javascript syntax=jasmine
+autocmd BufNewFile,BufRead,BufWritePost *[_.][Ss]pec.coffee,*SpecHelper.coffee set filetype=jasmine.coffee syntax=jasmine


### PR DESCRIPTION
Add support for jasmine-node. Specs should be named as something.spec.coffee or something.spec.js:

https://github.com/mhevery/jasmine-node

This should probably include changes in README, but I'm too lazy and don't know how to do that while applying the change directly from GitHub web interface ;)
